### PR TITLE
Adjustment for Kamba

### DIFF
--- a/sources/NotoSans-Italic.glyphspackage/fontinfo.plist
+++ b/sources/NotoSans-Italic.glyphspackage/fontinfo.plist
@@ -8241,6 +8241,7 @@ v.sc = -50;
 "@MMK_R_yi-cy" = 40;
 "@MMK_R_z.sc" = -10;
 "@MMK_R_ze-cy" = 10;
+itilde = 80;
 };
 "@MMK_L_r.left" = {
 "@MMK_R_a.right" = -20;
@@ -8516,6 +8517,9 @@ ampersand.sc = {
 "@MMK_R_y.sc" = -40;
 v.sc = -10;
 };
+apostrophemod = {
+itilde = 80;
+};
 b.sc = {
 "@MMK_R_t.sc" = -10;
 "@MMK_R_y.sc" = -10;
@@ -8543,6 +8547,9 @@ f.sc = {
 "@MMK_R_ae.sc" = -20;
 "@MMK_R_j.scsalt" = -40;
 "@MMK_R_period.right" = -30;
+};
+itilde = {
+itilde = 140;
 };
 k.sc = {
 "@MMK_R_c.sc" = -10;
@@ -9948,6 +9955,7 @@ v.sc = -50;
 "@MMK_R_yi-cy" = 40;
 "@MMK_R_z.sc" = -10;
 "@MMK_R_ze-cy" = 10;
+itilde = 70;
 };
 "@MMK_L_r.left" = {
 "@MMK_R_a.right" = -20;
@@ -10218,6 +10226,9 @@ ampersand.sc = {
 "@MMK_R_y.sc" = -40;
 v.sc = -10;
 };
+apostrophemod = {
+itilde = 70;
+};
 b.sc = {
 "@MMK_R_t.sc" = -10;
 "@MMK_R_y.sc" = -10;
@@ -10245,6 +10256,9 @@ f.sc = {
 "@MMK_R_ae.sc" = -20;
 "@MMK_R_j.scsalt" = -50;
 "@MMK_R_period.right" = -30;
+};
+itilde = {
+itilde = 110;
 };
 k.sc = {
 "@MMK_R_c.sc" = -10;
@@ -11655,6 +11669,7 @@ v.sc = -50;
 "@MMK_R_yi-cy" = 40;
 "@MMK_R_z.sc" = -10;
 "@MMK_R_ze-cy" = 10;
+itilde = 60;
 };
 "@MMK_L_r.left" = {
 "@MMK_R_a.right" = -20;
@@ -11927,6 +11942,9 @@ ampersand.sc = {
 "@MMK_R_y.sc" = -40;
 v.sc = -10;
 };
+apostrophemod = {
+itilde = 60;
+};
 b.sc = {
 "@MMK_R_t.sc" = -10;
 "@MMK_R_y.sc" = -10;
@@ -11955,6 +11973,9 @@ f.sc = {
 "@MMK_R_ae.sc" = -20;
 "@MMK_R_j.scsalt" = -70;
 "@MMK_R_period.right" = -30;
+};
+itilde = {
+itilde = 120;
 };
 k.sc = {
 "@MMK_R_c.sc" = -10;
@@ -13328,6 +13349,7 @@ v.sc = -50;
 "@MMK_R_yi-cy" = 30;
 "@MMK_R_z.sc" = -10;
 "@MMK_R_ze-cy" = -10;
+itilde = 70;
 };
 "@MMK_L_r.left" = {
 "@MMK_R_a.right" = -5;
@@ -13575,6 +13597,9 @@ ampersand.sc = {
 "@MMK_R_y.sc" = -30;
 v.sc = -10;
 };
+apostrophemod = {
+itilde = 70;
+};
 b.sc = {
 "@MMK_R_y.sc" = -10;
 question.sc = -10;
@@ -13602,6 +13627,9 @@ f.sc = {
 "@MMK_R_ae.sc" = -10;
 "@MMK_R_j.scsalt" = -30;
 "@MMK_R_period.right" = -40;
+};
+itilde = {
+itilde = 140;
 };
 k.sc = {
 "@MMK_R_c.sc" = -15;
@@ -14967,6 +14995,7 @@ v.sc = -50;
 "@MMK_R_yi-cy" = 30;
 "@MMK_R_z.sc" = -10;
 "@MMK_R_ze-cy" = -10;
+itilde = 50;
 };
 "@MMK_L_r.left" = {
 "@MMK_R_a.right" = -5;
@@ -15214,6 +15243,9 @@ ampersand.sc = {
 "@MMK_R_y.sc" = -30;
 v.sc = -10;
 };
+apostrophemod = {
+itilde = 50;
+};
 b.sc = {
 "@MMK_R_y.sc" = -10;
 question.sc = -10;
@@ -15241,6 +15273,9 @@ f.sc = {
 "@MMK_R_ae.sc" = -10;
 "@MMK_R_j.scsalt" = -30;
 "@MMK_R_period.right" = -40;
+};
+itilde = {
+itilde = 120;
 };
 k.sc = {
 "@MMK_R_c.sc" = -15;
@@ -16612,6 +16647,7 @@ v.sc = -50;
 "@MMK_R_yi-cy" = 30;
 "@MMK_R_z.sc" = -10;
 "@MMK_R_ze-cy" = -10;
+itilde = 60;
 };
 "@MMK_L_r.left" = {
 "@MMK_R_a.right" = -5;
@@ -16858,6 +16894,9 @@ ampersand.sc = {
 "@MMK_R_y.sc" = -30;
 v.sc = -10;
 };
+apostrophemod = {
+itilde = 60;
+};
 b.sc = {
 "@MMK_R_y.sc" = -10;
 question.sc = -10;
@@ -16885,6 +16924,9 @@ f.sc = {
 "@MMK_R_ae.sc" = -10;
 "@MMK_R_j.scsalt" = -40;
 "@MMK_R_period.right" = -40;
+};
+itilde = {
+itilde = 120;
 };
 k.sc = {
 "@MMK_R_c.sc" = -15;

--- a/sources/NotoSans.glyphspackage/fontinfo.plist
+++ b/sources/NotoSans.glyphspackage/fontinfo.plist
@@ -8636,6 +8636,7 @@ v.sc = -40;
 "@MMK_R_u-cy" = 20;
 "@MMK_R_yi-cy" = 30;
 "@MMK_R_ze-cy" = 20;
+itilde = 80;
 };
 "@MMK_L_r.left" = {
 "@MMK_R_a.right" = -20;
@@ -8885,6 +8886,9 @@ ampersand.sc = {
 tbar.sc = -30;
 v.sc = -30;
 };
+apostrophemod = {
+itilde = 70;
+};
 b.sc = {
 "@MMK_R_y.sc" = -10;
 };
@@ -8936,6 +8940,9 @@ guilsinglright.sc = {
 tbar.sc = -10;
 v.sc = -20;
 x.sc = -10;
+};
+itilde = {
+itilde = 150;
 };
 p.sc = {
 "@MMK_R_a.sc" = -30;
@@ -10270,6 +10277,7 @@ v.sc = -40;
 "@MMK_R_u-cy" = 20;
 "@MMK_R_yi-cy" = 30;
 "@MMK_R_ze-cy" = 20;
+itilde = 70;
 };
 "@MMK_L_r.left" = {
 "@MMK_R_a.right" = -20;
@@ -10520,6 +10528,9 @@ ampersand.sc = {
 tbar.sc = -30;
 v.sc = -30;
 };
+apostrophemod = {
+itilde = 70;
+};
 b.sc = {
 "@MMK_R_y.sc" = -10;
 };
@@ -10578,6 +10589,9 @@ guilsinglright.sc = {
 tbar.sc = -10;
 v.sc = -20;
 x.sc = -10;
+};
+itilde = {
+itilde = 130;
 };
 p.sc = {
 "@MMK_R_a.sc" = -30;
@@ -11909,6 +11923,7 @@ v.sc = -40;
 "@MMK_R_u-cy" = 20;
 "@MMK_R_yi-cy" = 30;
 "@MMK_R_ze-cy" = 20;
+itilde = 70;
 };
 "@MMK_L_r.left" = {
 "@MMK_R_a.right" = -20;
@@ -12158,6 +12173,9 @@ ampersand.sc = {
 tbar.sc = -30;
 v.sc = -30;
 };
+apostrophemod = {
+itilde = 70;
+};
 b.sc = {
 "@MMK_R_y.sc" = -10;
 };
@@ -12214,6 +12232,9 @@ guilsinglright.sc = {
 tbar.sc = -10;
 v.sc = -20;
 x.sc = -10;
+};
+itilde = {
+itilde = 110;
 };
 p.sc = {
 "@MMK_R_a.sc" = -30;
@@ -13511,6 +13532,7 @@ v.sc = -30;
 "@MMK_R_o.right" = -36;
 "@MMK_R_s.right" = -18;
 "@MMK_R_yi-cy" = 30;
+itilde = 60;
 };
 "@MMK_L_r.left" = {
 "@MMK_R_a.right" = -12;
@@ -13768,6 +13790,9 @@ ampersand.sc = {
 tbar.sc = -18;
 v.sc = -18;
 };
+apostrophemod = {
+itilde = 60;
+};
 b.sc = {
 "@MMK_R_y.sc" = -1;
 };
@@ -13820,6 +13845,9 @@ guilsinglright.sc = {
 tbar.sc = -6;
 v.sc = -12;
 x.sc = -6;
+};
+itilde = {
+itilde = 130;
 };
 p.sc = {
 "@MMK_R_a.sc" = -18;
@@ -15119,6 +15147,7 @@ v.sc = -30;
 "@MMK_R_o.right" = -36;
 "@MMK_R_s.right" = -18;
 "@MMK_R_yi-cy" = 30;
+itilde = 50;
 };
 "@MMK_L_r.left" = {
 "@MMK_R_a.right" = -12;
@@ -15375,6 +15404,9 @@ ampersand.sc = {
 tbar.sc = -18;
 v.sc = -18;
 };
+apostrophemod = {
+itilde = 50;
+};
 b.sc = {
 "@MMK_R_y.sc" = -1;
 };
@@ -15422,6 +15454,9 @@ guilsinglright.sc = {
 tbar.sc = -6;
 v.sc = -12;
 x.sc = -6;
+};
+itilde = {
+itilde = 110;
 };
 p.sc = {
 "@MMK_R_a.sc" = -18;
@@ -16726,6 +16761,7 @@ v.sc = -30;
 "@MMK_R_o.right" = -36;
 "@MMK_R_s.right" = -18;
 "@MMK_R_yi-cy" = 30;
+itilde = 40;
 };
 "@MMK_L_r.left" = {
 "@MMK_R_a.right" = -12;
@@ -16982,6 +17018,9 @@ ampersand.sc = {
 tbar.sc = -18;
 v.sc = -18;
 };
+apostrophemod = {
+itilde = 40;
+};
 b.sc = {
 "@MMK_R_y.sc" = -1;
 };
@@ -17029,6 +17068,9 @@ guilsinglright.sc = {
 tbar.sc = -6;
 v.sc = -12;
 x.sc = -6;
+};
+itilde = {
+itilde = 110;
 };
 p.sc = {
 "@MMK_R_a.sc" = -18;

--- a/sources/NotoSerif-Italic.glyphspackage/fontinfo.plist
+++ b/sources/NotoSerif-Italic.glyphspackage/fontinfo.plist
@@ -8556,6 +8556,7 @@ Jcrossedtail = 50;
 "@MMK_R_o-cy" = -10;
 "@MMK_R_s" = -50;
 "@MMK_R_u-cy" = 50;
+itilde = 20;
 };
 "@MMK_L_quotesinglbase" = {
 "@MMK_R_Che-cy" = -130;
@@ -9148,6 +9149,9 @@ germandbls.sc = {
 hmod = {
 "@MMK_R_quotesingle" = -27;
 "@MMK_R_y" = -13;
+};
+itilde = {
+itilde = 100;
 };
 kmod = {
 "@MMK_R_o" = -15;
@@ -10907,6 +10911,7 @@ Jcrossedtail = 37;
 "@MMK_R_o-cy" = -10;
 "@MMK_R_s" = -50;
 "@MMK_R_u-cy" = 50;
+itilde = 40;
 };
 "@MMK_L_quotesinglbase" = {
 "@MMK_R_Che-cy" = -130;
@@ -11434,6 +11439,9 @@ ampersand.sc = {
 "@MMK_R_v.sc" = -40;
 "@MMK_R_y.sc" = -30;
 };
+apostrophemod = {
+itilde = 40;
+};
 at = {
 "@MMK_R_GRK_Alpha" = -30;
 "@MMK_R_GRK_Psi" = -10;
@@ -11501,6 +11509,9 @@ germandbls.sc = {
 hmod = {
 "@MMK_R_quotesingle" = -27;
 "@MMK_R_y" = -13;
+};
+itilde = {
+itilde = 80;
 };
 kmod = {
 "@MMK_R_o" = -15;
@@ -13263,6 +13274,7 @@ Jcrossedtail = 22;
 "@MMK_R_o-cy" = -10;
 "@MMK_R_s" = -50;
 "@MMK_R_u-cy" = 50;
+itilde = 50;
 };
 "@MMK_L_quotesinglbase" = {
 "@MMK_R_Che-cy" = -130;
@@ -13790,6 +13802,9 @@ ampersand.sc = {
 "@MMK_R_v.sc" = -40;
 "@MMK_R_y.sc" = -30;
 };
+apostrophemod = {
+itilde = 50;
+};
 at = {
 "@MMK_R_GRK_Alpha" = -30;
 "@MMK_R_GRK_Psi" = -10;
@@ -13857,6 +13872,9 @@ germandbls.sc = {
 hmod = {
 "@MMK_R_quotesingle" = -27;
 "@MMK_R_y" = -13;
+};
+itilde = {
+itilde = 30;
 };
 kmod = {
 "@MMK_R_o" = -15;
@@ -15649,6 +15667,7 @@ Germandbls = -10;
 "@MMK_R_s" = -50;
 "@MMK_R_s.sc" = -20;
 "@MMK_R_u-cy" = 50;
+itilde = 40;
 };
 "@MMK_L_quotesinglbase" = {
 "@MMK_R_Che-cy" = -130;
@@ -16188,6 +16207,9 @@ ampersand.sc = {
 "@MMK_R_v.sc" = -40;
 "@MMK_R_y.sc" = -30;
 };
+apostrophemod = {
+itilde = 40;
+};
 at = {
 "@MMK_R_GRK_Alpha" = -30;
 "@MMK_R_GRK_Psi" = -10;
@@ -16256,6 +16278,9 @@ germandbls.sc = {
 hmod = {
 "@MMK_R_quotesingle" = -27;
 "@MMK_R_y" = -13;
+};
+itilde = {
+itilde = 90;
 };
 kmod = {
 "@MMK_R_o" = -15;
@@ -18046,6 +18071,7 @@ Germandbls = -10;
 "@MMK_R_s" = -50;
 "@MMK_R_s.sc" = -20;
 "@MMK_R_u-cy" = 50;
+itilde = 40;
 };
 "@MMK_L_quotesinglbase" = {
 "@MMK_R_Che-cy" = -130;
@@ -18583,6 +18609,9 @@ ampersand.sc = {
 "@MMK_R_v.sc" = -40;
 "@MMK_R_y.sc" = -30;
 };
+apostrophemod = {
+itilde = 40;
+};
 at = {
 "@MMK_R_GRK_Alpha" = -30;
 "@MMK_R_GRK_Psi" = -10;
@@ -18651,6 +18680,9 @@ germandbls.sc = {
 hmod = {
 "@MMK_R_quotesingle" = -27;
 "@MMK_R_y" = -13;
+};
+itilde = {
+itilde = 70;
 };
 kmod = {
 "@MMK_R_o" = -15;
@@ -20451,6 +20483,7 @@ Germandbls = -10;
 "@MMK_R_s" = -50;
 "@MMK_R_s.sc" = -20;
 "@MMK_R_u-cy" = 50;
+itilde = 50;
 };
 "@MMK_L_quotesinglbase" = {
 "@MMK_R_Che-cy" = -130;
@@ -20990,6 +21023,9 @@ ampersand.sc = {
 "@MMK_R_v.sc" = -40;
 "@MMK_R_y.sc" = -30;
 };
+apostrophemod = {
+itilde = 50;
+};
 at = {
 "@MMK_R_GRK_Alpha" = -30;
 "@MMK_R_GRK_Psi" = -10;
@@ -21058,6 +21094,9 @@ germandbls.sc = {
 hmod = {
 "@MMK_R_quotesingle" = -27;
 "@MMK_R_y" = -13;
+};
+itilde = {
+itilde = 30;
 };
 kmod = {
 "@MMK_R_o" = -15;

--- a/sources/NotoSerif.glyphspackage/fontinfo.plist
+++ b/sources/NotoSerif.glyphspackage/fontinfo.plist
@@ -7903,6 +7903,7 @@ Jcrossedtail = 40;
 "@MMK_R_a" = -30;
 "@MMK_R_o" = -40;
 "@MMK_R_s" = -50;
+itilde = 10;
 };
 "@MMK_L_quotesingle" = {
 "@MMK_R_A" = -80;
@@ -8399,6 +8400,9 @@ hmod = {
 };
 hturnedmod = {
 "@MMK_R_y" = -16;
+};
+itilde = {
+itilde = 50;
 };
 "iu-cy" = {
 "@MMK_R_cyr_Che" = -30;
@@ -9626,6 +9630,7 @@ Jcrossedtail = 34;
 "@MMK_R_a" = -30;
 "@MMK_R_o" = -40;
 "@MMK_R_s" = -50;
+itilde = 10;
 };
 "@MMK_L_quotesingle" = {
 "@MMK_R_A" = -80;
@@ -10125,6 +10130,9 @@ hmod = {
 };
 hturnedmod = {
 "@MMK_R_y" = -16;
+};
+itilde = {
+itilde = 60;
 };
 "iu-cy" = {
 "@MMK_R_cyr_Che" = -30;
@@ -11353,6 +11361,7 @@ Jcrossedtail = 44;
 "@MMK_R_a" = -30;
 "@MMK_R_o" = -40;
 "@MMK_R_s" = -50;
+itilde = 10;
 };
 "@MMK_L_quotesingle" = {
 "@MMK_R_A" = -80;
@@ -11779,6 +11788,9 @@ ampersand.sc = {
 "@MMK_R_w.sc" = -30;
 "@MMK_R_y.sc" = -20;
 };
+apostrophemod = {
+itilde = 10;
+};
 at = {
 "@MMK_R_A" = -30;
 "@MMK_R_GRK_Alpha" = -30;
@@ -11849,6 +11861,9 @@ hmod = {
 };
 hturnedmod = {
 "@MMK_R_y" = -16;
+};
+itilde = {
+itilde = 60;
 };
 "iu-cy" = {
 "@MMK_R_cyr_Che" = -30;
@@ -13092,6 +13107,7 @@ Jcrossedtail = 38;
 "@MMK_R_o" = -40;
 "@MMK_R_s" = -50;
 "@MMK_R_s.sc" = -20;
+itilde = 10;
 };
 "@MMK_L_quotesingle" = {
 "@MMK_R_A" = -80;
@@ -13486,6 +13502,9 @@ aogonek = {
 "@MMK_R_W" = -40;
 "@MMK_R_Y" = -40;
 };
+apostrophemod = {
+itilde = 10;
+};
 asterisk = {
 "@MMK_R_De-cy" = -70;
 };
@@ -13551,6 +13570,9 @@ hturnedmod = {
 };
 "io-cy" = {
 "@MMK_R_cyr_U" = -20;
+};
+itilde = {
+itilde = 60;
 };
 kmod = {
 "@MMK_R_o" = -16;
@@ -14801,6 +14823,7 @@ Jcrossedtail = 46;
 "@MMK_R_o" = -40;
 "@MMK_R_s" = -50;
 "@MMK_R_s.sc" = -20;
+itilde = 15;
 };
 "@MMK_L_quotesingle" = {
 "@MMK_R_A" = -80;
@@ -15198,6 +15221,9 @@ aogonek = {
 "@MMK_R_W" = -40;
 "@MMK_R_Y" = -40;
 };
+apostrophemod = {
+itilde = 20;
+};
 asterisk = {
 "@MMK_R_De-cy" = -70;
 };
@@ -15263,6 +15289,9 @@ hturnedmod = {
 };
 "io-cy" = {
 "@MMK_R_cyr_U" = -20;
+};
+itilde = {
+itilde = 60;
 };
 kmod = {
 "@MMK_R_o" = -16;
@@ -16518,6 +16547,7 @@ Jcrossedtail = 50;
 "@MMK_R_o" = -40;
 "@MMK_R_s" = -50;
 "@MMK_R_s.sc" = -20;
+itilde = 20;
 };
 "@MMK_L_quotesingle" = {
 "@MMK_R_A" = -80;
@@ -16914,6 +16944,9 @@ aogonek = {
 "@MMK_R_W" = -40;
 "@MMK_R_Y" = -40;
 };
+apostrophemod = {
+itilde = 20;
+};
 asterisk = {
 "@MMK_R_De-cy" = -70;
 };
@@ -16979,6 +17012,9 @@ hturnedmod = {
 };
 "io-cy" = {
 "@MMK_R_cyr_U" = -20;
+};
+itilde = {
+itilde = 60;
 };
 kmod = {
 "@MMK_R_o" = -16;


### PR DESCRIPTION
Hello. Thank you for providing us with great fonts.
I’d like to submit a pull request for Kamba support.

This fix targets the issue #393.
#393 was closed because it was included in #131, but the fix for #131 will need more major changes such as glyphs and kerning groups.
So, this time I try to fix only #393, “itilde” kerning was adjusted as kerning group exceptions.

**Sample**
ĩĩ ʼĩ ’ĩ
ĩ: U+0129
ʼ: U+02BC
’: U+2019

**Noto Sans Regular**
![image](https://github.com/user-attachments/assets/b5edba52-b151-46d8-bff5-25667cd3b2aa)
**Noto Sans Italic**
![image](https://github.com/user-attachments/assets/7b54575f-6b44-4a96-aee4-21d0a5f6d93b)
**Noto Sans Bold**
![image](https://github.com/user-attachments/assets/c80899bb-b94e-4120-a07e-7064404b349c)
**Noto Sans Bold Italic**
![image](https://github.com/user-attachments/assets/e1f10c50-cb9e-4157-817d-ffd73d71ddd9)

**Noto Serif Regular**
![image](https://github.com/user-attachments/assets/1bfc3e3b-d6f1-4f21-a793-498c18186f95)
**Noto Serif Italic**
![image](https://github.com/user-attachments/assets/28dd10e8-cf41-44c7-8d37-8cfaa8d7ec96)
**Noto Serif Bold**
![image](https://github.com/user-attachments/assets/e9aaf424-8215-4d21-90b7-c0823949dae3)
**Noto Serif Bold Italic**
![image](https://github.com/user-attachments/assets/b48e07e5-ed00-4c94-a0f8-fdb1f8d1f353)

Thank you for taking this request into consideration.
