### PR TITLE
Adjustment for Slovak and Czech languages

### DIFF
--- a/sources/NotoSans-Italic.glyphspackage/fontinfo.plist
+++ b/sources/NotoSans-Italic.glyphspackage/fontinfo.plist
@@ -7859,7 +7859,9 @@ x.sc = -10;
 "@MMK_L_dcaron" = {
 "@MMK_R_Paren.right" = 100;
 "@MMK_R_b" = 30;
-"@MMK_R_quote.right" = 40;
+"@MMK_R_quote.right" = 60;
+"@MMK_R_quoteleft" = 50;
+exclam = 40;
 hbar = 70;
 question = 80;
 };
@@ -9573,8 +9575,10 @@ v.sc = -5;
 x.sc = -10;
 };
 "@MMK_L_dcaron" = {
-"@MMK_R_Paren.right" = 100;
-"@MMK_R_quote.right" = 40;
+"@MMK_R_Paren.right" = 84;
+"@MMK_R_quote.right" = 70;
+"@MMK_R_quoteleft" = 40;
+exclam = 60;
 hbar = 70;
 question = 80;
 };
@@ -10296,6 +10300,10 @@ v.sc = -30;
 space = {
 "@MMK_R_E-cy" = -20;
 "@MMK_R_a-cy" = -20;
+};
+tcaron = {
+"@MMK_R_Paren.right" = 40;
+question = 20;
 };
 thorn.sc = {
 "@MMK_R_period.right" = -20;
@@ -11285,8 +11293,10 @@ v.sc = -5;
 x.sc = -10;
 };
 "@MMK_L_dcaron" = {
-"@MMK_R_Paren.right" = 100;
-"@MMK_R_quote.right" = 40;
+"@MMK_R_Paren.right" = 90;
+"@MMK_R_quote.right" = 80;
+"@MMK_R_quoteleft" = 30;
+exclam = 60;
 hbar = 70;
 question = 80;
 };
@@ -12013,6 +12023,13 @@ v.sc = -30;
 space = {
 "@MMK_R_E-cy" = -20;
 "@MMK_R_a-cy" = -20;
+};
+tcaron = {
+"@MMK_R_Paren.right" = 70;
+"@MMK_R_quote.right" = 50;
+"@MMK_R_quoteleft" = 30;
+exclam = 60;
+question = 50;
 };
 thorn.sc = {
 "@MMK_R_period.right" = -20;
@@ -13008,10 +13025,12 @@ v.sc = -5;
 x.sc = -10;
 };
 "@MMK_L_dcaron" = {
-"@MMK_R_Paren.right" = 120;
-"@MMK_R_quote.right" = 120;
+"@MMK_R_Paren.right" = 80;
+"@MMK_R_quote.right" = 80;
+"@MMK_R_quoteleft" = 50;
+exclam = 40;
 hbar = 140;
-question = 130;
+question = 110;
 };
 "@MMK_L_de-cy" = {
 "@MMK_R_quote.right" = -10;
@@ -13656,6 +13675,13 @@ questiondown.sc = {
 "@MMK_R_w.sc" = -20;
 "@MMK_R_y.sc" = -30;
 v.sc = -30;
+};
+tcaron = {
+"@MMK_R_Paren.right" = 70;
+"@MMK_R_quote.right" = 50;
+"@MMK_R_quoteleft" = 40;
+exclam = 20;
+question = 70;
 };
 thorn.sc = {
 "@MMK_R_period.right" = -30;
@@ -14654,10 +14680,12 @@ v.sc = -5;
 x.sc = -10;
 };
 "@MMK_L_dcaron" = {
-"@MMK_R_Paren.right" = 120;
-"@MMK_R_quote.right" = 120;
+"@MMK_R_Paren.right" = 40;
+"@MMK_R_quote.right" = 40;
+"@MMK_R_quoteleft" = 20;
+exclam = 20;
 hbar = 140;
-question = 130;
+question = 50;
 };
 "@MMK_L_de-cy" = {
 "@MMK_R_quote.right" = -10;
@@ -15308,6 +15336,13 @@ questiondown.sc = {
 "@MMK_R_w.sc" = -20;
 "@MMK_R_y.sc" = -30;
 v.sc = -30;
+};
+tcaron = {
+"@MMK_R_Paren.right" = 60;
+"@MMK_R_quote.right" = 30;
+"@MMK_R_quoteleft" = 30;
+exclam = 20;
+question = 60;
 };
 thorn.sc = {
 "@MMK_R_period.right" = -30;
@@ -16305,10 +16340,11 @@ v.sc = -5;
 x.sc = -10;
 };
 "@MMK_L_dcaron" = {
-"@MMK_R_Paren.right" = 120;
-"@MMK_R_quote.right" = 120;
+"@MMK_R_Paren.right" = 70;
+"@MMK_R_quote.right" = 50;
+exclam = 50;
 hbar = 140;
-question = 130;
+question = 60;
 };
 "@MMK_L_de-cy" = {
 "@MMK_R_quote.right" = -10;
@@ -16959,6 +16995,12 @@ questiondown.sc = {
 "@MMK_R_w.sc" = -20;
 "@MMK_R_y.sc" = -30;
 v.sc = -30;
+};
+tcaron = {
+"@MMK_R_Paren.right" = 80;
+"@MMK_R_quote.right" = 40;
+exclam = 40;
+question = 50;
 };
 thorn.sc = {
 "@MMK_R_period.right" = -30;

--- a/sources/NotoSans.glyphspackage/fontinfo.plist
+++ b/sources/NotoSans.glyphspackage/fontinfo.plist
@@ -8302,6 +8302,8 @@ x.sc = -10;
 "@MMK_R_Paren.right" = 70;
 "@MMK_R_b" = 30;
 "@MMK_R_quote.right" = 40;
+"@MMK_R_quoteleft" = 50;
+exclam = 10;
 hbar = 70;
 question = 80;
 };
@@ -8975,6 +8977,13 @@ tbar.sc = {
 "@MMK_R_period.right" = -20;
 ampersand.sc = -10;
 guilsinglleft.sc = -10;
+};
+tcaron = {
+"@MMK_R_Paren.right" = 70;
+"@MMK_R_quote.right" = 40;
+"@MMK_R_quoteleft" = 40;
+exclam = 30;
+question = 50;
 };
 thorn.sc = {
 "@MMK_R_a.sc" = -10;
@@ -9940,11 +9949,13 @@ guilsinglleft.sc = -10;
 x.sc = -10;
 };
 "@MMK_L_dcaron" = {
-"@MMK_R_Paren.right" = 70;
+"@MMK_R_Paren.right" = 90;
 "@MMK_R_b" = 30;
-"@MMK_R_quote.right" = 40;
+"@MMK_R_quote.right" = 50;
+"@MMK_R_quoteleft" = 70;
+exclam = 50;
 hbar = 70;
-question = 80;
+question = 90;
 };
 "@MMK_L_de-cy" = {
 "@MMK_R_Che-cy" = -15;
@@ -10624,6 +10635,13 @@ tbar.sc = {
 "@MMK_R_period.right" = -20;
 ampersand.sc = -10;
 guilsinglleft.sc = -10;
+};
+tcaron = {
+"@MMK_R_Paren.right" = 120;
+"@MMK_R_quote.right" = 90;
+"@MMK_R_quoteleft" = 70;
+exclam = 70;
+question = 110;
 };
 thorn.sc = {
 "@MMK_R_a.sc" = -10;
@@ -11586,11 +11604,13 @@ guilsinglleft.sc = -10;
 x.sc = -10;
 };
 "@MMK_L_dcaron" = {
-"@MMK_R_Paren.right" = 70;
+"@MMK_R_Paren.right" = 180;
 "@MMK_R_b" = 30;
-"@MMK_R_quote.right" = 40;
+"@MMK_R_quote.right" = 140;
+"@MMK_R_quoteleft" = 108;
+exclam = 160;
 hbar = 70;
-question = 80;
+question = 160;
 };
 "@MMK_L_de-cy" = {
 "@MMK_R_Che-cy" = -15;
@@ -12267,6 +12287,13 @@ tbar.sc = {
 "@MMK_R_period.right" = -20;
 ampersand.sc = -10;
 guilsinglleft.sc = -10;
+};
+tcaron = {
+"@MMK_R_Paren.right" = 190;
+"@MMK_R_quote.right" = 130;
+"@MMK_R_quoteleft" = 110;
+exclam = 170;
+question = 160;
 };
 thorn.sc = {
 "@MMK_R_a.sc" = -10;
@@ -13198,9 +13225,11 @@ guilsinglleft.sc = -6;
 x.sc = -6;
 };
 "@MMK_L_dcaron" = {
-"@MMK_R_Paren.right" = 72;
+"@MMK_R_Paren.right" = 42;
 "@MMK_R_b" = 58;
-"@MMK_R_quote.right" = 74;
+"@MMK_R_quote.right" = 54;
+"@MMK_R_quoteleft" = 30;
+exclam = 40;
 hbar = 72;
 question = 58;
 };
@@ -13885,6 +13914,13 @@ tbar.sc = {
 "@MMK_R_period.right" = -20;
 ampersand.sc = -6;
 guilsinglleft.sc = -6;
+};
+tcaron = {
+"@MMK_R_Paren.right" = 60;
+"@MMK_R_quote.right" = 32;
+"@MMK_R_quoteleft" = 40;
+exclam = 30;
+question = 70;
 };
 thorn.sc = {
 "@MMK_R_a.sc" = -6;
@@ -14813,11 +14849,13 @@ guilsinglleft.sc = -6;
 x.sc = -6;
 };
 "@MMK_L_dcaron" = {
-"@MMK_R_Paren.right" = 72;
+"@MMK_R_Paren.right" = 82;
 "@MMK_R_b" = 58;
 "@MMK_R_quote.right" = 74;
+"@MMK_R_quoteleft" = 50;
+exclam = 60;
 hbar = 72;
-question = 58;
+question = 88;
 };
 "@MMK_L_de-cy" = {
 "@MMK_R_Che-cy" = -10;
@@ -15494,6 +15532,13 @@ tbar.sc = {
 "@MMK_R_period.right" = -20;
 ampersand.sc = -6;
 guilsinglleft.sc = -6;
+};
+tcaron = {
+"@MMK_R_Paren.right" = 120;
+"@MMK_R_quote.right" = 72;
+"@MMK_R_quoteleft" = 60;
+exclam = 80;
+question = 110;
 };
 thorn.sc = {
 "@MMK_R_a.sc" = -6;
@@ -16424,11 +16469,13 @@ guilsinglleft.sc = -6;
 x.sc = -6;
 };
 "@MMK_L_dcaron" = {
-"@MMK_R_Paren.right" = 72;
+"@MMK_R_Paren.right" = 182;
 "@MMK_R_b" = 58;
-"@MMK_R_quote.right" = 74;
+"@MMK_R_quote.right" = 154;
+"@MMK_R_quoteleft" = 100;
+exclam = 150;
 hbar = 72;
-question = 58;
+question = 158;
 };
 "@MMK_L_de-cy" = {
 "@MMK_R_Che-cy" = -10;
@@ -17108,6 +17155,13 @@ tbar.sc = {
 "@MMK_R_period.right" = -20;
 ampersand.sc = -6;
 guilsinglleft.sc = -6;
+};
+tcaron = {
+"@MMK_R_Paren.right" = 180;
+"@MMK_R_quote.right" = 152;
+"@MMK_R_quoteleft" = 100;
+exclam = 150;
+question = 170;
 };
 thorn.sc = {
 "@MMK_R_a.sc" = -6;

--- a/sources/NotoSerif-Italic.glyphspackage/fontinfo.plist
+++ b/sources/NotoSerif-Italic.glyphspackage/fontinfo.plist
@@ -8209,10 +8209,11 @@ x.sc = -10;
 "@MMK_R_b" = 90;
 "@MMK_R_l" = 90;
 "@MMK_R_parenright" = 70;
-"@MMK_R_quoteleft" = 30;
+"@MMK_R_quoteleft" = 50;
 "@MMK_R_quoteright" = 40;
-"@MMK_R_quotesingle" = 30;
-question = 30;
+"@MMK_R_quotesingle" = 50;
+exclam = 30;
+question = 50;
 };
 "@MMK_L_de-cy" = {
 "@MMK_R_A-cy" = -20;
@@ -9213,6 +9214,13 @@ schwa = {
 "@MMK_R_izhitsa-cy" = -20;
 "@MMK_R_u-cy" = -20;
 rhotichookmod = 60;
+};
+tcaron = {
+"@MMK_R_parenright" = 50;
+"@MMK_R_quoteleft" = 20;
+"@MMK_R_quotesingle" = 20;
+exclam = 20;
+question = 10;
 };
 underscore = {
 "@MMK_R_Che-cy" = -110;
@@ -10566,11 +10574,12 @@ x.sc = -10;
 "@MMK_R_Z" = 80;
 "@MMK_R_b" = 90;
 "@MMK_R_l" = 90;
-"@MMK_R_parenright" = 70;
-"@MMK_R_quoteleft" = 30;
+"@MMK_R_parenright" = 80;
+"@MMK_R_quoteleft" = 40;
 "@MMK_R_quoteright" = 40;
-"@MMK_R_quotesingle" = 30;
-question = 30;
+"@MMK_R_quotesingle" = 70;
+exclam = 30;
+question = 40;
 };
 "@MMK_L_de-cy" = {
 "@MMK_R_A-cy" = -20;
@@ -11572,6 +11581,10 @@ rsubscript = {
 schwa = {
 "@MMK_R_izhitsa-cy" = -20;
 "@MMK_R_u-cy" = -20;
+};
+tcaron = {
+"@MMK_R_parenright" = 40;
+"@MMK_R_quotesingle" = 20;
 };
 underscore = {
 "@MMK_R_Che-cy" = -110;
@@ -12929,11 +12942,12 @@ x.sc = -10;
 "@MMK_R_Z" = 80;
 "@MMK_R_b" = 90;
 "@MMK_R_l" = 90;
-"@MMK_R_parenright" = 70;
+"@MMK_R_parenright" = 150;
 "@MMK_R_quoteleft" = 30;
 "@MMK_R_quoteright" = 40;
-"@MMK_R_quotesingle" = 30;
-question = 30;
+"@MMK_R_quotesingle" = 90;
+exclam = 30;
+question = 100;
 };
 "@MMK_L_de-cy" = {
 "@MMK_R_A-cy" = -20;
@@ -13935,6 +13949,11 @@ rsubscript = {
 schwa = {
 "@MMK_R_izhitsa-cy" = -20;
 "@MMK_R_u-cy" = -20;
+};
+tcaron = {
+"@MMK_R_parenright" = 70;
+"@MMK_R_quotesingle" = 30;
+question = 40;
 };
 underscore = {
 "@MMK_R_Che-cy" = -110;
@@ -15311,7 +15330,8 @@ x.sc = -10;
 "@MMK_R_quoteleft" = 30;
 "@MMK_R_quoteright" = 40;
 "@MMK_R_quotesingle" = 30;
-question = 30;
+exclam = 30;
+question = 40;
 };
 "@MMK_L_de-cy" = {
 "@MMK_R_A-cy" = -20;
@@ -16344,6 +16364,13 @@ schwa = {
 "@MMK_R_izhitsa-cy" = -20;
 "@MMK_R_u-cy" = -20;
 rhotichookmod = 40;
+};
+tcaron = {
+"@MMK_R_parenright" = 50;
+"@MMK_R_quoteleft" = 20;
+"@MMK_R_quotesingle" = 20;
+exclam = 20;
+question = 10;
 };
 underscore = {
 "@MMK_R_Che-cy" = -110;
@@ -17715,11 +17742,12 @@ x.sc = -10;
 "@MMK_R_Z" = 80;
 "@MMK_R_b" = 90;
 "@MMK_R_l" = 90;
-"@MMK_R_parenright" = 70;
-"@MMK_R_quoteleft" = 30;
+"@MMK_R_parenright" = 90;
+"@MMK_R_quoteleft" = 50;
 "@MMK_R_quoteright" = 40;
-"@MMK_R_quotesingle" = 30;
-question = 30;
+"@MMK_R_quotesingle" = 80;
+exclam = 30;
+question = 60;
 };
 "@MMK_L_de-cy" = {
 "@MMK_R_A-cy" = -20;
@@ -18745,6 +18773,11 @@ rsubscript = {
 schwa = {
 "@MMK_R_izhitsa-cy" = -20;
 "@MMK_R_u-cy" = -20;
+};
+tcaron = {
+"@MMK_R_parenright" = 30;
+"@MMK_R_quotesingle" = 20;
+question = 10;
 };
 underscore = {
 "@MMK_R_Che-cy" = -110;
@@ -20117,11 +20150,12 @@ x.sc = -10;
 "@MMK_R_Z" = 80;
 "@MMK_R_b" = 90;
 "@MMK_R_l" = 90;
-"@MMK_R_parenright" = 70;
-"@MMK_R_quoteleft" = 30;
+"@MMK_R_parenright" = 120;
+"@MMK_R_quoteleft" = 40;
 "@MMK_R_quoteright" = 40;
-"@MMK_R_quotesingle" = 30;
-question = 30;
+"@MMK_R_quotesingle" = 90;
+exclam = 40;
+question = 100;
 };
 "@MMK_L_de-cy" = {
 "@MMK_R_A-cy" = -20;
@@ -21159,6 +21193,11 @@ rsubscript = {
 schwa = {
 "@MMK_R_izhitsa-cy" = -20;
 "@MMK_R_u-cy" = -20;
+};
+tcaron = {
+"@MMK_R_parenright" = 70;
+"@MMK_R_quotesingle" = 40;
+question = 60;
 };
 underscore = {
 "@MMK_R_Che-cy" = -110;

--- a/sources/NotoSerif.glyphspackage/fontinfo.plist
+++ b/sources/NotoSerif.glyphspackage/fontinfo.plist
@@ -7771,8 +7771,9 @@ x.sc = -10;
 "@MMK_R_Y" = 100;
 "@MMK_R_Z" = 40;
 "@MMK_R_l" = 90;
-"@MMK_R_parenright" = 60;
+"@MMK_R_parenright" = 20;
 "@MMK_R_quoteright" = 40;
+"@MMK_R_quotesingle" = 20;
 question = 30;
 };
 "@MMK_L_de-cy" = {
@@ -9498,9 +9499,12 @@ x.sc = -10;
 "@MMK_R_Y" = 100;
 "@MMK_R_Z" = 40;
 "@MMK_R_l" = 90;
-"@MMK_R_parenright" = 60;
+"@MMK_R_parenright" = 80;
+"@MMK_R_quoteleft" = 10;
 "@MMK_R_quoteright" = 40;
-question = 30;
+"@MMK_R_quotesingle" = 50;
+exclam = 20;
+question = 60;
 };
 "@MMK_L_de-cy" = {
 "@MMK_R_parenright" = 20;
@@ -10218,6 +10222,9 @@ schwa = {
 };
 tcaron = {
 "@MMK_R_l" = 40;
+"@MMK_R_parenright" = 50;
+"@MMK_R_quotesingle" = 20;
+question = 20;
 };
 thorn.sc = {
 "@MMK_R_a.sc" = -10;
@@ -11229,9 +11236,12 @@ x.sc = -10;
 "@MMK_R_Y" = 100;
 "@MMK_R_Z" = 40;
 "@MMK_R_l" = 90;
-"@MMK_R_parenright" = 60;
+"@MMK_R_parenright" = 160;
+"@MMK_R_quoteleft" = 40;
 "@MMK_R_quoteright" = 40;
-question = 30;
+"@MMK_R_quotesingle" = 100;
+exclam = 90;
+question = 93;
 };
 "@MMK_L_de-cy" = {
 "@MMK_R_parenright" = 20;
@@ -11949,6 +11959,11 @@ schwa = {
 };
 tcaron = {
 "@MMK_R_l" = 41;
+"@MMK_R_parenright" = 110;
+"@MMK_R_quoteleft" = 10;
+"@MMK_R_quotesingle" = 60;
+exclam = 40;
+question = 50;
 };
 thorn.sc = {
 "@MMK_R_a.sc" = -10;
@@ -12959,7 +12974,9 @@ x.sc = -10;
 "@MMK_R_Z" = 40;
 "@MMK_R_l" = 90;
 "@MMK_R_parenright" = 60;
+"@MMK_R_quoteleft" = 10;
 "@MMK_R_quoteright" = 40;
+"@MMK_R_quotesingle" = 50;
 question = 30;
 };
 "@MMK_L_de-cy" = {
@@ -13665,6 +13682,7 @@ rhotichookmod = 30;
 };
 tcaron = {
 "@MMK_R_l" = 40;
+"@MMK_R_parenright" = 30;
 };
 thorn.sc = {
 "@MMK_R_a.sc" = -10;
@@ -14674,9 +14692,12 @@ x.sc = -10;
 "@MMK_R_Y" = 100;
 "@MMK_R_Z" = 40;
 "@MMK_R_l" = 90;
-"@MMK_R_parenright" = 60;
+"@MMK_R_parenright" = 80;
+"@MMK_R_quoteleft" = 10;
 "@MMK_R_quoteright" = 40;
-question = 30;
+"@MMK_R_quotesingle" = 60;
+exclam = 20;
+question = 40;
 };
 "@MMK_L_de-cy" = {
 "@MMK_R_parenright" = 20;
@@ -15389,6 +15410,8 @@ schwa = {
 };
 tcaron = {
 "@MMK_R_l" = 40;
+"@MMK_R_parenright" = 50;
+"@MMK_R_quotesingle" = 20;
 };
 thorn.sc = {
 "@MMK_R_a.sc" = -10;
@@ -16398,9 +16421,12 @@ x.sc = -10;
 "@MMK_R_Y" = 100;
 "@MMK_R_Z" = 40;
 "@MMK_R_l" = 90;
-"@MMK_R_parenright" = 60;
+"@MMK_R_parenright" = 140;
+"@MMK_R_quoteleft" = 40;
 "@MMK_R_quoteright" = 40;
-question = 30;
+"@MMK_R_quotesingle" = 90;
+exclam = 70;
+question = 90;
 };
 "@MMK_L_de-cy" = {
 "@MMK_R_parenright" = 20;
@@ -17112,6 +17138,10 @@ schwa = {
 };
 tcaron = {
 "@MMK_R_l" = 40;
+"@MMK_R_parenright" = 90;
+"@MMK_R_quotesingle" = 50;
+exclam = 20;
+question = 40;
 };
 thorn.sc = {
 "@MMK_R_a.sc" = -10;


### PR DESCRIPTION
Hello. Thank you for providing us with great fonts.
I’d like to submit a pull request for Slovak and Czech languages support.

This fix targets the issue [#485](https://github.com/notofonts/latin-greek-cyrillic/issues/485).
There should be more space between “caron” and brackets, punctuations, and quotations. 
So, I adjusted the “dcaron” kerning group, and “lcaron”, which have the same class as “dcaron”.
For some “tcaron” pairs which are included in “t” kerning group, I made them as an exception and adjusted so that it won’t affect kerning of “t”.

**Sample**
(ď) "ď" !ď! ?ď? ‘ď‘ [ď]
(ľ) "ľ" !ľ! ?ľ? ‘ľ‘ [ľ]
(ť) "ť" !ť! ?ť? ‘ť‘ [ť]
ď: U+010F
ľ: U+013E
ť: U+0165
): U+0029
": U+0022
!: U+0021
?: U+003F
‘: U+2018
]: U+005D

**Noto Sans Regular**
![image](https://github.com/user-attachments/assets/7e7f3fde-2c58-464a-b4d0-3cdcda924267)
**Noto Sans Italic**
![image](https://github.com/user-attachments/assets/4990865f-970b-4859-911f-57b6d77f7fe2)
**Noto Sans Bold**
![image](https://github.com/user-attachments/assets/324fc12d-9c5f-474a-aac7-f239b72d2749)
**Noto Sans Bold Italic**
![image](https://github.com/user-attachments/assets/0a050154-8a20-4902-84c4-aac5d3372db5)
**Noto Serif Regular**
![image](https://github.com/user-attachments/assets/0e5b357d-6ebf-4c70-923b-a8ea1e45b5ad)
**Noto Serif Italic**
![image](https://github.com/user-attachments/assets/688ae8b9-8353-4a2b-8a87-21128fc962c9)
**Noto Serif Bold**
![image](https://github.com/user-attachments/assets/ebb6b038-f5ba-4213-af0f-e85ce51eb6e9)
**Noto Serif Bold Italic**
![image](https://github.com/user-attachments/assets/5e0d3e54-10bd-4680-b947-a47da77d65bf)


Thank you for taking this request into consideration.